### PR TITLE
Add basic pod debugging and a comment on nodeSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ The last line of the log will be an url to the image you just generated :)
 
 If you are more interested in a docker in docker type of workload, you would do something like this: https://gist.github.com/saienduri/67e8b1687bc08e9b9519e1febea23f80
 
-## Debugging
+## Debugging and Basic Usage
 
-Please following [Debug Running Pods](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/) if your job fails.
+- Please following [Debug Running Pods](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/) if your job fails.
+- [Get a shell to a running container for interactive development](https://kubernetes.io/docs/tasks/debug/debug-application/get-shell-running-container/)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ are welcome!
 
 ### Option 1: Base ROCm Job
 
-If you want to just run a quick test, please use the `rocm-job-template.yaml` in this repo. 
+If you want to just run a quick test, please use the `rocm-job-template.yaml` in this repo.
 All this job is configured to do is a run a hello-world to see if GPUs are available.
 Please change the job name to include your username. This is a shared namespace, so it helps avoid job contention/conflict with other jobs with the same name and helps us track better as well.
 Please use your assigned namespace in the kubernetes cluster. If you are just using anon.conf, you can use the `dev` namespace.
@@ -72,3 +72,7 @@ This script will dispatch the job, display logs when finished, and delete the jo
 The last line of the log will be an url to the image you just generated :)
 
 If you are more interested in a docker in docker type of workload, you would do something like this: https://gist.github.com/saienduri/67e8b1687bc08e9b9519e1febea23f80
+
+## Debugging
+
+Please following [Debug Running Pods](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/) if your job fails.

--- a/rocm-job-template.yaml
+++ b/rocm-job-template.yaml
@@ -11,8 +11,6 @@ metadata:
 spec:
   template:
     spec:
-      nodeSelector:
-        dev: "true"
       containers:
       - name: rocm-test-container
         image: rocm/tensorflow:latest

--- a/rocm-job-template.yaml
+++ b/rocm-job-template.yaml
@@ -11,6 +11,11 @@ metadata:
 spec:
   template:
     spec:
+      # please comment the nodeSelector like below if your pod fails to schedule
+      # nodeSelector:
+      #   dev: "true"
+      nodeSelector:
+        dev: "true"
       containers:
       - name: rocm-test-container
         image: rocm/tensorflow:latest

--- a/shark-job-template.yaml
+++ b/shark-job-template.yaml
@@ -8,6 +8,11 @@ metadata:
 spec:
   template:
     spec:
+      # please comment the nodeSelector like below if your pod fails to schedule
+      # nodeSelector:
+      #   dev: "true"
+      nodeSelector:
+        dev: "true"
       containers:
       - name: shark-test-container
         image: rocm/dev-ubuntu-22.04:6.3

--- a/shark-job-template.yaml
+++ b/shark-job-template.yaml
@@ -8,8 +8,6 @@ metadata:
 spec:
   template:
     spec:
-      nodeSelector:
-        dev: "true"
       containers:
       - name: shark-test-container
         image: rocm/dev-ubuntu-22.04:6.3


### PR DESCRIPTION
- Include Kubernetes's debugging pod page for user's reference
- The dev node selector is giving us a lot of trouble. Removing it to simplify out of the box experience