### PR TITLE
Adding KUBECONFIG path validation instead of directly checking anon.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Run these two commands to pull in all the required dependencies and set the appr
 
 Linux:
 ```
-./linux/setup_k8s.sh
 export KUBECONFIG = "/path/to/your/anon.conf"
+./linux/setup_k8s.sh
 ```
 
 Windows PowerShell (elevated permissions required, so run as admin):
 ```
-.\windows\setup_k8s.ps1
 $env:KUBECONFIG = "C:\path\to\your\anon.conf"
+.\windows\setup_k8s.ps1
 ```
 
 Refer to https://kubernetes.io/docs/tasks/tools/ if you would rather install kubectl manually.

--- a/linux/setup_k8s.sh
+++ b/linux/setup_k8s.sh
@@ -6,10 +6,18 @@ set -e
 
 echo "Starting Kubernetes setup..."
 
-if [ ! -f "anon.conf" ]; then
-  echo "Please download anon.conf from the AMD OSSCI confluence site to get started"
+# Exit early if KUBECONFIG is not set to a valid path
+if [ -z "$KUBECONFIG" ]; then
+  echo "KUBECONFIG is not set or empty. Exiting"
+  echo "Please download the authentication file from the AMD OSSCI confluence site and set KUBECONFIG env variable to the file path"
   echo "You will need this auth file to access the k8s cluster"
   exit 1
+elif [ ! -f "$KUBECONFIG" ]; then
+  echo "File $KUBECONFIG does not exit. Exiting"
+  echo "Plese make sure the KUBECONFIG env variable is correctly set to the authentication file path"
+  exit 1
+else
+  echo "KUBECONFIG is set to: $KUBECONFIG"
 fi
 
 echo "Downloading kubectl..."


### PR DESCRIPTION
Small tweak to the KUBECONFIG setup.

- Issue: Noticed that setup fails if anon.conf is not present in the same directory as the setup file. This is contradictory to exposing an environment variable KUBECONFIG that can be set to a path outside of the repo as well.

- Fix: Instead of checking for existence of anon.conf in the same directory as the setup script, check if KUBECONFIG is set up correctly. Also modified README as KUBECONFIG now should be set before running the setup.