### PR TITLE
Add KUBECONFIG environment variable validation for windows

### DIFF
--- a/windows/setup_k8s.ps1
+++ b/windows/setup_k8s.ps1
@@ -42,7 +42,23 @@ if ($calculatedHash -eq $expectedHash) {
 }
 
 # Requires elevated powershell
-Write-Host "Adding current directory to PATH..."
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine) + ";$PWD"
+# Check if the current directory is already present in PATH
+$path = [System.Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::Machine)
+
+if ($path -split ';' -contains $PWD) {
+    Write-Host "The current directory $PWD is already in the PATH."
+} else {
+    Write-Host "The current directory $PWD is not in the PATH. Adding..."
+    
+    [System.Environment]::SetEnvironmentVariable(
+        "Path",
+        $path + ";$PWD", 
+        [System.EnvironmentVariableTarget]::Machine
+    )
+
+    # Also modify the current context
+    $env:Path = $path + ";$PWD"
+}
 
 Write-Host "Setup completed successfully!"
+Write-Host "If you want to run jobs from a different elevated powershell session, make sure to set the KUBECONFIG env variable again."

--- a/windows/setup_k8s.ps1
+++ b/windows/setup_k8s.ps1
@@ -7,10 +7,21 @@ $kubectlVersion = "v1.32.0"
 
 Write-Host "Starting kubernetes setup..."
 
-if (-not (Test-Path -Path "anon.conf" -PathType Leaf)) {
-    Write-Host "Please download anon.conf from the AMD OSSCI confluence site to get started"
+# Exit early if KUBECONFIG is not set to a valid path
+$kubeconfigPath = [System.Environment]::GetEnvironmentVariable('KUBECONFIG')
+if ( -not $kubeconfigPath) {
+    Write-Host "KUBECONFIG is not set or empty. Exiting"
+    Write-Host "Please download the authentication file from the AMD OSSCI confluence site and set KUBECONFIG env variable to the file path"
     Write-Host "You will need this auth file to access the k8s cluster"
     exit 1
+}
+elseif ( -not (Test-Path -Path $kubeconfigPath)) {
+    Write-Host "File $kubeconfigPath does not exit. Exiting"
+    Write-Host "Plese make sure the KUBECONFIG env variable is correctly set to the authentication file path"
+    exit 1
+}
+else {
+    Write-Host "KUBECONFIG is set to: $kubeconfigPath"
 }
 
 Write-Host "Downloading kubectl..."
@@ -32,10 +43,6 @@ if ($calculatedHash -eq $expectedHash) {
 
 # Requires elevated powershell
 Write-Host "Adding current directory to PATH..."
-[System.Environment]::SetEnvironmentVariable(
-    "Path",
-    [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine) + ";$PWD",
-    [System.EnvironmentVariableTarget]::Machine
-)
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", [System.EnvironmentVariableTarget]::Machine) + ";$PWD"
 
 Write-Host "Setup completed successfully!"


### PR DESCRIPTION
Similar to the changes made for linux setup: https://github.com/nod-ai/ossci-fleet/pull/11

Small tweak to the KUBECONFIG setup.

- Issue: Noticed that setup fails if anon.conf is not present in the same directory as the setup file. This is contradictory to exposing an environment variable KUBECONFIG that can be set to a path outside of the repo as well.

- Fix: Instead of checking for existence of anon.conf in the same directory as the setup script, check if KUBECONFIG is set up correctly.