### PR TITLE
Add a script to repair port-forwarding after a connection loss

### DIFF
--- a/example-templates/interactive/vscode/repair-port-forward.sh
+++ b/example-templates/interactive/vscode/repair-port-forward.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Restores port-forwarding to an existing pod. If `kubectl port-forward` command
+# is still running, kills it and reruns it. Else, constructs a `kubectl port-forward`
+# command for an existing pod listed by `kubectl get pods`.
+
+set -euo pipefail
+
+pattern="kubectl port-forward"
+
+ps_entry="$(ps a | (grep -F "${pattern}" || true) | (grep -v grep || true))"
+
+if [[ -n "$ps_entry" ]]
+then
+  echo "Found existing process: $ps_entry"
+  pid="$(echo "$ps_entry" | grep -o '^[[:space:]]*[0-9]\+')"
+  command="$(echo "$ps_entry" | grep -o 'kubectl.*')"
+  echo "Killing $pid..."
+  kill $pid
+  echo "Rerunning command $command..."
+  $command
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_FILE="${SCRIPT_DIR}/config.json"
+NAMESPACE=$(jq -r '.namespace' "$CONFIG_FILE")
+
+get_pods_entry="$(kubectl get pods -n "$NAMESPACE" | (grep "\binteractive-vscode-${USER}\b" || true))"
+
+if [[ -z "$get_pods_entry" ]]
+then
+  echo "No running pod."
+  exit 1
+fi
+  
+echo "Found running pod: $get_pods_entry"
+pod_name="$(echo "$get_pods_entry" | grep -o '^[^[:space:]]\+')"
+echo "Pod name: $pod_name"
+command="kubectl port-forward -n $NAMESPACE $pod_name 2222:22"
+echo "Executing: $command"
+$command
+exit 0


### PR DESCRIPTION
After reconnecting to the network, typically `run-vscode-interactive.sh` is still running, `kubectl port-forward` is still running as a child process of it, but the port forwarding isn't effective anymore on the client side, while still there on the server side preventing just running  `kubectl port-forward` again. The existing `kubectl port-forward` needs to be killed first. However, the  `run-vscode-interactive.sh` script in its current form traps SIGINT and performs pod deletion at that point.

This PR adds a script so that the workflow to recover from connection loss is just to run that script. This way, `run-vscode-interactive.sh` is not interrupted, pod deletion doesn't happen and one can resume working on the current pod.