### PR TITLE
Add fsGroupChangePolicy to interactive dev template.

### DIFF
--- a/example-templates/interactive/vscode/vscode-session-ssh.yml
+++ b/example-templates/interactive/vscode/vscode-session-ssh.yml
@@ -14,6 +14,7 @@ spec:
     runAsUser: 1001
     runAsGroup: 1001
     fsGroup: 1001
+    fsGroupChangePolicy: OnRootMismatch
   containers:
     - name: vscode-ssh
       # Docker image to use for the interactive vscode session.


### PR DESCRIPTION
Setting `fsGroupChangePolicy: OnRootMismatch` so it doesn't change perms recursively for all files in the PVC every time. This way it will only do it once and all future pods won't need to do it as part of init. This should speed mount setup for runners.

Not a disruptive change, and it should only help.

https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods