### PR TITLE
Support multiple concurrent interactive sessions

### DIFF
--- a/example-templates/interactive/vscode/README.md
+++ b/example-templates/interactive/vscode/README.md
@@ -1,6 +1,6 @@
 # Interactive VSCode Session
 
-The OSSCI Fleet aims to provide central infrastructure to enable developer access to support AIG’s GPU software development, leveraging our in-house GPU as a Service (GPUaaS) platform.
+The OSSCI Fleet aims to provide central infrastructure to enable developer access to support AIG's GPU software development, leveraging our in-house GPU as a Service (GPUaaS) platform.
 This guide covers how to start an interactive vscode session.
 
 ## Prerequisites
@@ -11,6 +11,37 @@ Please follow [PVC Provisioning Instructions](https://amd.atlassian.net/wiki/spa
 
 Update [config.json](./config.json) to your assigned namespace, PVC, and path to public ssh key. The SSH key is the public ssh key of the host that you want to use to remote connect with VSCode or ssh directly in terminal to the pod.
 
+## Configuration
+
+All settings are in [config.json](./config.json):
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `namespace` | Yes | — | Your Kubernetes namespace |
+| `pvc` | Yes | — | Your Persistent Volume Claim name |
+| `public_ssh_key_path` | Yes | — | Path to your SSH public key |
+| `image` | No | `ossci-dev:main` | Docker image for the session (must be Ubuntu/Debian-based) |
+| `dev_user` | No | `root` | Username for SSH login |
+| `dev_uid` | No | `0` | UID for the dev user |
+| `dev_gid` | No | `0` | GID for the dev user |
+| `home_dir` | No | `/home/ossci` | PVC mount path (persistent home directory) |
+| `gpu_limit` | No | `1` | Number of AMD GPUs to allocate |
+
+### Using a Custom Image
+
+You can use any Ubuntu/Debian-based Docker image by setting the `image` field in `config.json`:
+
+```json
+{
+  "namespace": "my-namespace",
+  "pvc": "my-pvc",
+  "public_ssh_key_path": "/home/user/.ssh/id_rsa.pub",
+  "image": "ubuntu:24.04"
+}
+```
+
+The SSH setup (installing `openssh-server`, creating the user, configuring keys) is handled automatically at pod startup regardless of the image. The image must support `apt-get`.
+
 ## VSCode Setup
 
 You can launch a VSCode interactive environment inside your assigned Kubernetes namespace with your existing Persistent Volume Claim (PVC).
@@ -19,19 +50,21 @@ The environment supports two modes — browser-based (web) and SSH-based (ssh).
 ### SSH Mode
 
 Runs a VSCode environment accessible via the VS Code Remote SSH extension.
-The script forwards the pod’s SSH port (22) to your local machine (2222).
+The script forwards the pod's SSH port (22) to your local machine (2222).
 
 Add the following entry to your local `~/.ssh/config`:
 
 ```bash
 Host ossci
   HostName 127.0.0.1
-  User ossci
+  User root
   Port 2222
-  IdentityFile \Users\esaimana\.ssh\id_rsa
+  IdentityFile ~/.ssh/id_rsa
   StrictHostKeyChecking no
   UserKnownHostsFile /dev/null
 ```
+
+If you changed `dev_user` in config.json, update the `User` field above to match.
 
 You can connect either via the VS Code Remote SSH extension:
 
@@ -72,7 +105,7 @@ cd ossci-fleet/example-templates/interactive/vscode
 ./run-vscode-interactive.sh <web|ssh>
 ```
 
-The script reads your configuration from [config.json](./config.json) (namespace, PVC, SSH key) and automatically deploys the appropriate pod in your namespace.
+The script reads your configuration from [config.json](./config.json) (namespace, PVC, SSH key, image) and automatically deploys the appropriate pod in your namespace.
 
 Feel free to edit [vscode ssh](./vscode-session-ssh.yml) or [vscode web](./vscode-session-web.yml) templates if you would like to change the docker image or number of gpus that the VSCode interactive session comes up with.
 
@@ -90,8 +123,8 @@ Find the latest tarballs for all architectures here: https://therock-nightly-tar
 Add the following to your `.bashrc` or `.zshrc`:
 
 ```bash
-export PATH=$HOME/therock-tarball/bin:$PATH
-export LD_LIBRARY_PATH=$HOME/therock-tarball/lib
+export PATH=$HOME/therock-tarball/install/bin:$PATH
+export LD_LIBRARY_PATH=$HOME/therock-tarball/install/lib
 ```
 
 If you would like to use TheRock python packages or build from source, please refer to [therock.md](../the-rock/therock.md)

--- a/example-templates/interactive/vscode/README.md
+++ b/example-templates/interactive/vscode/README.md
@@ -26,6 +26,8 @@ All settings are in [config.json](./config.json):
 | `dev_gid` | No | `0` | GID for the dev user |
 | `home_dir` | No | `/home/ossci` | PVC mount path (persistent home directory) |
 | `gpu_limit` | No | `1` | Number of AMD GPUs to allocate |
+| `local_ssh_port` | No | `2222` | Local port for SSH forwarding |
+| `local_web_port` | No | `8000` | Local port for web mode forwarding |
 
 ### Using a Custom Image
 
@@ -102,7 +104,14 @@ ssh -L 8000:localhost:8000 user@hostname
 ```bash
 git clone git@github.com:nod-ai/ossci-fleet.git
 cd ossci-fleet/example-templates/interactive/vscode
-./run-vscode-interactive.sh <web|ssh>
+./run-vscode-interactive.sh [--config config.json] <web|ssh>
+```
+
+You can maintain multiple config files for different setups (e.g., different images and local ports for concurrent sessions):
+
+```bash
+./run-vscode-interactive.sh --config config-pytorch.json ssh
+./run-vscode-interactive.sh --config config-ubuntu.json ssh
 ```
 
 The script reads your configuration from [config.json](./config.json) (namespace, PVC, SSH key, image) and automatically deploys the appropriate pod in your namespace.

--- a/example-templates/interactive/vscode/config.json
+++ b/example-templates/interactive/vscode/config.json
@@ -2,5 +2,6 @@
   "namespace": "my-namespace",
   "pvc": "my-pvc",
   "public_ssh_key_path": "/home/user/.ssh/id_rsa.pub",
-  "image": "rocm/pytorch:latest"
+  "image": "rocm/pytorch:latest",
+  "local_ssh_port": "2222"
 }

--- a/example-templates/interactive/vscode/config.json
+++ b/example-templates/interactive/vscode/config.json
@@ -1,5 +1,6 @@
 {
-  "namespace": "ossci-test",
-  "pvc": "ossci-test-pvc",
-  "public_ssh_key_path": "/home/user/.ssh/ossci.pub"
+  "namespace": "my-namespace",
+  "pvc": "my-pvc",
+  "public_ssh_key_path": "/home/user/.ssh/id_rsa.pub",
+  "image": "rocm/pytorch:latest"
 }

--- a/example-templates/interactive/vscode/run-vscode-interactive.sh
+++ b/example-templates/interactive/vscode/run-vscode-interactive.sh
@@ -5,19 +5,36 @@ EXIT_CODE=0
 
 # Default values
 POD_NAME="interactive-vscode-${USER}-$(date +%s)-$RANDOM"
-LOCAL_PORT="8000"
 REMOTE_PORT="9000"
 # Get the directory where this script resides (absolute path)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMP_YAML="${SCRIPT_DIR}/vscode-session-temp.yml"
+
+MODE=""
 CONFIG_FILE="${SCRIPT_DIR}/config.json"
 
-MODE=${1:-}
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        web|ssh)
+            MODE="$1"
+            shift
+            ;;
+        --config)
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
 
-if [[ -z "$MODE" || ( "$MODE" != "web" && "$MODE" != "ssh" ) ]]; then
-  echo "Usage: $0 <web|ssh>"
-  echo "  web : run browser-based VSCode server"
-  echo "  ssh : run remote SSH-accessible VSCode environment"
+if [[ -z "$MODE" ]]; then
+  echo "Usage: $0 [--config config.json] <web|ssh>"
+  echo "  --config : path to config file (default: ./config.json)"
+  echo "  web      : run browser-based VSCode server"
+  echo "  ssh      : run remote SSH-accessible VSCode environment"
   exit 1
 fi
 
@@ -47,6 +64,8 @@ DEV_USER_NAME=$(jq -r '.dev_user // "root"' "$CONFIG_FILE")
 DEV_UID=$(jq -r '.dev_uid // "0"' "$CONFIG_FILE")
 DEV_GID=$(jq -r '.dev_gid // "0"' "$CONFIG_FILE")
 HOME_DIR=$(jq -r '.home_dir // "/home/ossci"' "$CONFIG_FILE")
+LOCAL_SSH_PORT=$(jq -r '.local_ssh_port // "2222"' "$CONFIG_FILE")
+LOCAL_WEB_PORT=$(jq -r '.local_web_port // "8000"' "$CONFIG_FILE")
 
 YAML_TEMPLATE="${SCRIPT_DIR}/vscode-session-${MODE}.yml"
 
@@ -132,10 +151,10 @@ if [[ "$MODE" == "web" ]]; then
     kubectl logs --follow -n "$NAMESPACE" "$POD_NAME" &
 
     echo "VSCode is ready!"
-    echo "Starting port-forward from localhost:$LOCAL_PORT to pod:$REMOTE_PORT..."
-    echo "Access VSCode in your browser at: http://localhost:$LOCAL_PORT"
+    echo "Starting port-forward from localhost:$LOCAL_WEB_PORT to pod:$REMOTE_PORT..."
+    echo "Access VSCode in your browser at: http://localhost:$LOCAL_WEB_PORT"
     echo "Press Ctrl+C to stop and cleanup."
-    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" "$LOCAL_PORT:$REMOTE_PORT"
+    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" "$LOCAL_WEB_PORT:$REMOTE_PORT"
 else
     # Run SSH setup inside the pod via kubectl exec.
     # Pipes setup-ssh.sh into the pod — no ConfigMap needed.
@@ -152,7 +171,7 @@ else
 
     echo ""
     echo "SSH daemon is ready!"
-    echo "Starting port-forward (localhost:2222 -> pod:22)..."
+    echo "Starting port-forward (localhost:$LOCAL_SSH_PORT -> pod:22)..."
     echo "Please make sure your ~/.ssh/config is setup as instructed in README"
     echo "Once active, open VS Code and select:"
     echo "   'Remote-SSH: Connect to Host...'"
@@ -164,5 +183,5 @@ else
     echo "Your SSH public key has already been added to the pod."
     echo "Press Ctrl+C to stop and clean up."
     echo ""
-    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" 2222:22
+    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" "$LOCAL_SSH_PORT:22"
 fi

--- a/example-templates/interactive/vscode/run-vscode-interactive.sh
+++ b/example-templates/interactive/vscode/run-vscode-interactive.sh
@@ -28,20 +28,25 @@ if [ ! -f "$CONFIG_FILE" ]; then
   "namespace": "my-namespace",
   "pvc": "my-pvc",
   "public_ssh_key_path": "/path/to/id_rsa.pub",
+  "image": "ubuntu:24.04"
 }
 EOF
     exit 1
 fi
 
-# Read config
+# Read config (required fields)
 NAMESPACE=$(jq -r '.namespace' "$CONFIG_FILE")
 PVC_CLAIM_NAME=$(jq -r '.pvc' "$CONFIG_FILE")
 PUB_KEY_PATH=$(jq -r '.public_ssh_key_path' "$CONFIG_FILE")
 
-if [[ "$MODE" != "web" && "$MODE" != "ssh" ]]; then
-    echo "Error: mode in config.json must be 'web' or 'ssh'"
-    exit 1
-fi
+# Read config (optional fields with defaults)
+IMAGE=$(jq -r '.image // empty' "$CONFIG_FILE")
+IMAGE="${IMAGE:-ghcr.io/nod-ai/ossci-gitops/ossci-dev:main@sha256:4d76f74015ac2345ee17ef182921e00bc8d24feee39e36ae91906e2979e3c93e}"
+GPU_LIMIT=$(jq -r '.gpu_limit // "1"' "$CONFIG_FILE")
+DEV_USER_NAME=$(jq -r '.dev_user // "root"' "$CONFIG_FILE")
+DEV_UID=$(jq -r '.dev_uid // "0"' "$CONFIG_FILE")
+DEV_GID=$(jq -r '.dev_gid // "0"' "$CONFIG_FILE")
+HOME_DIR=$(jq -r '.home_dir // "/home/ossci"' "$CONFIG_FILE")
 
 YAML_TEMPLATE="${SCRIPT_DIR}/vscode-session-${MODE}.yml"
 
@@ -59,6 +64,10 @@ cleanup() {
         echo "Pod deleted successfully."
     else
         echo "Warning: Pod may have already been deleted or does not exist."
+    fi
+
+    if [[ "$MODE" == "ssh" ]]; then
+        kubectl delete secret "ssh-key-${POD_NAME}" -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
     fi
 
     rm -f "$TEMP_YAML"
@@ -87,18 +96,23 @@ if [[ "$MODE" == "ssh" ]]; then
     fi
     TMPDIR=$(mktemp -d)
     cp "$PUB_KEY_PATH" "$TMPDIR/authorized_keys"
-    SECRET_NAME="vscode-ssh-key-${USER}"
-    kubectl -n "$NAMESPACE" delete secret "$SECRET_NAME" --ignore-not-found
+    SECRET_NAME="ssh-key-${POD_NAME}"
     kubectl -n "$NAMESPACE" create secret generic "$SECRET_NAME" --from-file=authorized_keys="$TMPDIR/authorized_keys"
     rm -rf "$TMPDIR"
-    echo "✅ Created/updated SSH key secret in namespace '$NAMESPACE'."
+    echo "Created SSH key secret '$SECRET_NAME'."
 fi
 
-# Render YAML
+# Render YAML (use | as delimiter since image URLs contain /)
 echo "Preparing YAML from template: $YAML_TEMPLATE"
-sed -e "s/{{POD_NAME}}/${POD_NAME}/g" \
-    -e "s/{{PVC_CLAIM_NAME}}/${PVC_CLAIM_NAME}/g" \
-    -e "s/{{USER}}/${USER}/g" \
+echo "Using image: $IMAGE"
+sed -e "s|{{POD_NAME}}|${POD_NAME}|g" \
+    -e "s|{{PVC_CLAIM_NAME}}|${PVC_CLAIM_NAME}|g" \
+    -e "s|{{IMAGE}}|${IMAGE}|g" \
+    -e "s|{{GPU_LIMIT}}|${GPU_LIMIT}|g" \
+    -e "s|{{DEV_USER}}|${DEV_USER_NAME}|g" \
+    -e "s|{{DEV_UID}}|${DEV_UID}|g" \
+    -e "s|{{DEV_GID}}|${DEV_GID}|g" \
+    -e "s|{{HOME_DIR}}|${HOME_DIR}|g" \
     "$YAML_TEMPLATE" > "$TEMP_YAML"
 
 echo "Checking if pod '$POD_NAME' exists in namespace '$NAMESPACE'..."
@@ -110,39 +124,38 @@ fi
 echo "Applying '$TEMP_YAML' in namespace '$NAMESPACE'..."
 kubectl apply -f "$TEMP_YAML" -n "$NAMESPACE"
 
-echo "Waiting for pod '$POD_NAME' to be ready..."
+echo "Waiting for pod '$POD_NAME' to be running..."
 kubectl wait pod "$POD_NAME" -n "$NAMESPACE" --for=condition=Ready --timeout=300s
 
-echo "Pod is ready!"
-echo "Waiting for service to start..."
-
-# Start following logs in the background.
-kubectl logs --follow -n "$NAMESPACE" "$POD_NAME" &
-
 if [[ "$MODE" == "web" ]]; then
-    # Wait for VSCode web server port 9000
-    echo "Waiting for VSCode service on port $REMOTE_PORT..."
-    until kubectl exec -n "$NAMESPACE" "$POD_NAME" -- curl -fs http://localhost:$REMOTE_PORT/ >/dev/null 2>&1; do
-        echo "VSCode not ready yet, waiting..."
-        sleep 10
-    done
+    # Start following logs in the background.
+    kubectl logs --follow -n "$NAMESPACE" "$POD_NAME" &
+
     echo "VSCode is ready!"
     echo "Starting port-forward from localhost:$LOCAL_PORT to pod:$REMOTE_PORT..."
     echo "Access VSCode in your browser at: http://localhost:$LOCAL_PORT"
     echo "Press Ctrl+C to stop and cleanup."
     kubectl port-forward -n "$NAMESPACE" "$POD_NAME" "$LOCAL_PORT:$REMOTE_PORT"
 else
-    # Wait for SSH daemon port 22
-    echo "Waiting for SSH service on port 22..."
+    # Run SSH setup inside the pod via kubectl exec.
+    # Pipes setup-ssh.sh into the pod — no ConfigMap needed.
+    echo "Setting up SSH inside the pod..."
+    kubectl exec -i -n "$NAMESPACE" "$POD_NAME" -- \
+        env DEV_USER="$DEV_USER_NAME" DEV_UID="$DEV_UID" DEV_GID="$DEV_GID" HOME_DIR="$HOME_DIR" \
+        bash < "${SCRIPT_DIR}/setup-ssh.sh"
+
+    # Wait for sshd to be listening on port 22
+    echo "Waiting for SSH daemon on port 22..."
     until kubectl exec -n "$NAMESPACE" "$POD_NAME" -- bash -c "timeout 1 bash -c '</dev/tcp/localhost/22'" 2>/dev/null; do
-        echo "SSH not ready yet, waiting..."
-        sleep 5
+        sleep 2
     done
+
     echo ""
+    echo "SSH daemon is ready!"
     echo "Starting port-forward (localhost:2222 -> pod:22)..."
     echo "Please make sure your ~/.ssh/config is setup as instructed in README"
     echo "Once active, open VS Code and select:"
-    echo "   ➜  'Remote-SSH: Connect to Host...'"
+    echo "   'Remote-SSH: Connect to Host...'"
     echo "Then choose:"
     echo "   ossci  "
     echo ""

--- a/example-templates/interactive/vscode/setup-ssh.sh
+++ b/example-templates/interactive/vscode/setup-ssh.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -eu
+
+# Configuration via environment variables (passed by run-vscode-interactive.sh)
+DEV_USER="${DEV_USER:-root}"
+DEV_UID="${DEV_UID:-0}"
+DEV_GID="${DEV_GID:-0}"
+HOME_DIR="${HOME_DIR:-/home/ossci}"
+SSH_KEY_MOUNT="${SSH_KEY_MOUNT:-/mnt/sshkey}"
+
+echo "=== SSH Setup ==="
+echo "User: ${DEV_USER} (UID=${DEV_UID}, GID=${DEV_GID}, home=${HOME_DIR})"
+
+# --- Install openssh-server and sudo ---
+apt-get update -y
+apt-get install -y openssh-server sudo
+
+# --- Generate SSH host keys if missing ---
+if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then
+    ssh-keygen -A
+fi
+
+# --- Create user if not present ---
+if id "${DEV_USER}" >/dev/null 2>&1; then
+    echo "User '${DEV_USER}' already exists."
+else
+    echo "Creating user '${DEV_USER}'..."
+    groupadd -g "${DEV_GID}" "${DEV_USER}" 2>/dev/null || true
+    useradd -m -u "${DEV_UID}" -g "${DEV_GID}" -s /bin/bash "${DEV_USER}"
+fi
+
+# Non-root users get passwordless sudo and GPU group access
+if [[ "${DEV_USER}" != "root" ]]; then
+    echo "${DEV_USER} ALL=(ALL) NOPASSWD:ALL" > "/etc/sudoers.d/${DEV_USER}"
+    chmod 440 "/etc/sudoers.d/${DEV_USER}"
+
+    for grp in render video; do
+        if getent group "${grp}" >/dev/null 2>&1; then
+            usermod -aG "${grp}" "${DEV_USER}" 2>/dev/null || true
+        fi
+    done
+fi
+
+# --- Point user's home directory to the PVC mount ---
+sed -i "s|^\(${DEV_USER}:[^:]*:[^:]*:[^:]*:[^:]*:\)[^:]*|\1${HOME_DIR}|" /etc/passwd
+
+# --- Fix home directory ownership (non-recursive for speed) ---
+chown "${DEV_USER}:${DEV_GID}" "${HOME_DIR}"
+
+# --- Setup SSH authorized keys ---
+SSH_DIR="${HOME_DIR}/.ssh"
+
+mkdir -p "${SSH_DIR}"
+cp "${SSH_KEY_MOUNT}/authorized_keys" "${SSH_DIR}/authorized_keys"
+chmod 700 "${SSH_DIR}"
+chmod 600 "${SSH_DIR}/authorized_keys"
+chown -R "${DEV_USER}:${DEV_GID}" "${SSH_DIR}"
+
+# --- Configure sshd ---
+SSHD_CONFIG="/etc/ssh/sshd_config"
+if [ -f "${SSHD_CONFIG}" ]; then
+    grep -q "^PubkeyAuthentication yes" "${SSHD_CONFIG}" || echo "PubkeyAuthentication yes" >> "${SSHD_CONFIG}"
+    grep -q "^PasswordAuthentication no" "${SSHD_CONFIG}" || echo "PasswordAuthentication no" >> "${SSHD_CONFIG}"
+    # Allow root login via SSH key when dev_user is root
+    if [[ "${DEV_USER}" == "root" ]]; then
+        sed -i 's/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/' "${SSHD_CONFIG}"
+    fi
+fi
+
+# --- Propagate container environment to SSH sessions ---
+# sshd sanitizes the environment for security. Dockerfile ENV vars (PATH,
+# LD_LIBRARY_PATH, etc.) are available in this process but won't be inherited
+# by SSH login sessions. Write them to /etc/profile.d/ so login shells pick
+# them up — this is the standard Linux mechanism for system-wide env vars.
+SKIP_VARS="^(HOME|USER|LOGNAME|SHELL|TERM|HOSTNAME|PWD|OLDPWD|_|SHLVL|DEV_USER|DEV_UID|DEV_GID|HOME_DIR|SSH_KEY_MOUNT|KUBERNETES_.*|DEBIAN_FRONTEND)="
+env | grep -vE "${SKIP_VARS}" | while IFS='=' read -r key value; do
+    echo "export ${key}=\"${value}\""
+done > /etc/profile.d/container-env.sh
+
+# --- Start sshd (daemonized) ---
+mkdir -p /var/run/sshd
+echo "Starting sshd..."
+/usr/sbin/sshd
+echo "sshd started."

--- a/example-templates/interactive/vscode/setup-ssh.sh
+++ b/example-templates/interactive/vscode/setup-ssh.sh
@@ -12,8 +12,9 @@ echo "=== SSH Setup ==="
 echo "User: ${DEV_USER} (UID=${DEV_UID}, GID=${DEV_GID}, home=${HOME_DIR})"
 
 # --- Install openssh-server and sudo ---
-apt-get update -y
-apt-get install -y openssh-server sudo
+echo "Installing openssh-server..."
+apt-get update -y > /dev/null 2>&1
+apt-get install -y openssh-server sudo > /dev/null 2>&1
 
 # --- Generate SSH host keys if missing ---
 if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then

--- a/example-templates/interactive/vscode/vscode-session-ssh.yml
+++ b/example-templates/interactive/vscode/vscode-session-ssh.yml
@@ -9,52 +9,23 @@ spec:
         claimName: {{PVC_CLAIM_NAME}}
     - name: ssh-key
       secret:
-        secretName: vscode-ssh-key-{{USER}}
+        secretName: ssh-key-{{POD_NAME}}
   securityContext:
-    runAsUser: 1001
-    runAsGroup: 1001
-    fsGroup: 1001
+    runAsUser: 0
+    runAsGroup: 0
+    fsGroup: {{DEV_GID}}
     fsGroupChangePolicy: OnRootMismatch
   containers:
     - name: vscode-ssh
-      # Docker image to use for the interactive vscode session.
-      # Can change to any image that builds off this one.
-      image: ghcr.io/nod-ai/ossci-gitops/ossci-dev:main@sha256:4d76f74015ac2345ee17ef182921e00bc8d24feee39e36ae91906e2979e3c93e
-      command:
-        - /bin/bash
-        - -c
-        - |
-          set -eux
-          sudo apt-get update && sudo apt-get install -y sudo openssh-server curl vim
-
-          # Ensure proper ownership. No -R: that was taking very long and the
-          # ownership issue seems to be only about /home/ossci itself.
-          sudo chown ossci:ossci /home/ossci
-
-          # Setup SSH access
-          mkdir -p /home/ossci/.ssh
-          cp /mnt/sshkey/authorized_keys /home/ossci/.ssh/authorized_keys
-          chmod 700 /home/ossci/.ssh
-          chmod 600 /home/ossci/.ssh/authorized_keys
-
-          # People using the xx.sh script to rsync between a persistent
-          # directory (/home/ossci/xx) and a local directory (/tmp/xx) may have
-          # vscode sessions depending on /tmp/xx being present on startup.
-          # To avoid glitches, let's start with /tmp/xx as a symlink.
-          # Then the xx.sh script will delete it and create /tmp/xx as a dir.
-          ln -s /home/ossci/xx /tmp/xx
-
-          # Start SSH daemon
-          sudo mkdir -p /var/run/sshd
-          sudo /usr/sbin/sshd -D
+      image: {{IMAGE}}
+      command: ["sleep", "infinity"]
       volumeMounts:
         - name: home-vol
-          mountPath: /home/ossci
+          mountPath: {{HOME_DIR}}
           readOnly: false
         - name: ssh-key
           mountPath: /mnt/sshkey
           readOnly: true
       resources:
-        # Number of gpus available in the interactive vscode session.
         limits:
-          amd.com/gpu: 1
+          amd.com/gpu: {{GPU_LIMIT}}


### PR DESCRIPTION
## Summary
- Add `--config` flag to specify alternate config files, enabling multiple concurrent sessions with different images/ports
- Add configurable local forwarding ports (`local_ssh_port`, `local_web_port`) in config.json
- Quiet apt-get output during SSH setup

## Test plan
- [ ] Run `./run-vscode-interactive.sh ssh` with default config (backward compatible)
- [ ] Run `./run-vscode-interactive.sh --config custom.json ssh` with a custom config using a different local port
- [ ] Verify two concurrent sessions work with different `local_ssh_port` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)