### PR TITLE
Support multiple concurrent interactive sessions

### DIFF
--- a/example-templates/interactive/vscode/README.md
+++ b/example-templates/interactive/vscode/README.md
@@ -26,6 +26,8 @@ All settings are in [config.json](./config.json):
 | `dev_gid` | No | `0` | GID for the dev user |
 | `home_dir` | No | `/home/ossci` | PVC mount path (persistent home directory) |
 | `gpu_limit` | No | `1` | Number of AMD GPUs to allocate |
+| `local_ssh_port` | No | `2222` | Local port for SSH forwarding |
+| `local_web_port` | No | `8000` | Local port for web mode forwarding |
 
 ### Using a Custom Image
 
@@ -50,7 +52,7 @@ The environment supports two modes — browser-based (web) and SSH-based (ssh).
 ### SSH Mode
 
 Runs a VSCode environment accessible via the VS Code Remote SSH extension.
-The script forwards the pod's SSH port (22) to your local machine (2222).
+The script forwards the pod's SSH port (22) to your local machine (default: 2222, configurable via `local_ssh_port` in config.json).
 
 Add the following entry to your local `~/.ssh/config`:
 
@@ -66,35 +68,57 @@ Host ossci
 
 If you changed `dev_user` in config.json, update the `User` field above to match.
 
+For multiple concurrent sessions using different `local_ssh_port` values, add a separate entry for each:
+
+```bash
+Host ossci-pytorch
+  HostName 127.0.0.1
+  User root
+  Port 2222
+  IdentityFile ~/.ssh/id_rsa
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+
+Host ossci-ubuntu
+  HostName 127.0.0.1
+  User root
+  Port 2223
+  IdentityFile ~/.ssh/id_rsa
+  StrictHostKeyChecking no
+  UserKnownHostsFile /dev/null
+```
+
 You can connect either via the VS Code Remote SSH extension:
 
 Remote-SSH: Connect to Host...
-→ ossci
+→ Select the host name from your `~/.ssh/config` (e.g., `ossci`, `ossci-pytorch`)
 
 
 or directly from your terminal:
 
-ssh ossci
+```bash
+ssh ossci          # or whatever Host name you configured
+```
 
 If you are planning to use a remote host to start this interactive VSCode session, please ssh tunnel so that the ssh session that gets started is available on your local machine:
 
 ```bash
-ssh -L 2222:localhost:2222 user@hostname
+ssh -L <local_ssh_port>:localhost:<local_ssh_port> user@hostname
 ```
 
 ### Web Mode
 
 Runs a browser-accessible VSCode server inside a pod.
-Once ready, the script automatically forwards port 9000 from the pod to your local port 8000.
+Once ready, the script automatically forwards port 9000 from the pod to your local machine (default: 8000, configurable via `local_web_port` in config.json).
 
 Access it in your browser at:
 
-http://localhost:8000
+http://localhost:\<local_web_port\>
 
 If you are planning to use a remote host to start this interactive VSCode session, please ssh tunnel so that the ssh session that gets started is available on your local machine:
 
 ```bash
-ssh -L 8000:localhost:8000 user@hostname
+ssh -L <local_web_port>:localhost:<local_web_port> user@hostname
 ```
 
 ### Usage
@@ -102,12 +126,45 @@ ssh -L 8000:localhost:8000 user@hostname
 ```bash
 git clone git@github.com:nod-ai/ossci-fleet.git
 cd ossci-fleet/example-templates/interactive/vscode
-./run-vscode-interactive.sh <web|ssh>
+./run-vscode-interactive.sh
 ```
 
-The script reads your configuration from [config.json](./config.json) (namespace, PVC, SSH key, image) and automatically deploys the appropriate pod in your namespace.
+By default, the script starts in SSH mode. To use web mode instead:
 
-Feel free to edit [vscode ssh](./vscode-session-ssh.yml) or [vscode web](./vscode-session-web.yml) templates if you would like to change the docker image or number of gpus that the VSCode interactive session comes up with.
+```bash
+./run-vscode-interactive.sh web
+```
+
+You can run multiple concurrent sessions by creating separate config files. The main fields to change between configs are `image` and `local_ssh_port` (each session needs a unique local port):
+
+```json
+// config-pytorch.json
+{
+  "namespace": "my-namespace",
+  "pvc": "my-pvc",
+  "public_ssh_key_path": "~/.ssh/id_rsa.pub",
+  "image": "rocm/pytorch:latest",
+  "local_ssh_port": "2222"
+}
+
+// config-ubuntu.json
+{
+  "namespace": "my-namespace",
+  "pvc": "my-pvc",
+  "public_ssh_key_path": "~/.ssh/id_rsa.pub",
+  "image": "ubuntu:24.04",
+  "local_ssh_port": "2223"
+}
+```
+
+```bash
+./run-vscode-interactive.sh --config config-pytorch.json
+./run-vscode-interactive.sh --config config-ubuntu.json
+```
+
+The script reads your configuration from [config.json](./config.json) (namespace, PVC, SSH key, image, local ports) and automatically deploys the appropriate pod in your namespace.
+
+The Docker image, number of GPUs, and other settings are all configurable via config.json — no need to edit the YAML templates directly.
 
 #### Install ROCm
 

--- a/example-templates/interactive/vscode/config.json
+++ b/example-templates/interactive/vscode/config.json
@@ -2,5 +2,6 @@
   "namespace": "my-namespace",
   "pvc": "my-pvc",
   "public_ssh_key_path": "/home/user/.ssh/id_rsa.pub",
-  "image": "rocm/pytorch:latest"
+  "image": "rocm/pytorch:latest",
+  "local_ssh_port": "2222"
 }

--- a/example-templates/interactive/vscode/run-vscode-interactive.sh
+++ b/example-templates/interactive/vscode/run-vscode-interactive.sh
@@ -5,21 +5,30 @@ EXIT_CODE=0
 
 # Default values
 POD_NAME="interactive-vscode-${USER}-$(date +%s)-$RANDOM"
-LOCAL_PORT="8000"
 REMOTE_PORT="9000"
 # Get the directory where this script resides (absolute path)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TEMP_YAML="${SCRIPT_DIR}/vscode-session-temp.yml"
+
+MODE="ssh"
 CONFIG_FILE="${SCRIPT_DIR}/config.json"
 
-MODE=${1:-}
-
-if [[ -z "$MODE" || ( "$MODE" != "web" && "$MODE" != "ssh" ) ]]; then
-  echo "Usage: $0 <web|ssh>"
-  echo "  web : run browser-based VSCode server"
-  echo "  ssh : run remote SSH-accessible VSCode environment"
-  exit 1
-fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        web|ssh)
+            MODE="$1"
+            shift
+            ;;
+        --config)
+            CONFIG_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
 
 if [ ! -f "$CONFIG_FILE" ]; then
     echo "Error: config.json not found. Example format:"
@@ -47,6 +56,8 @@ DEV_USER_NAME=$(jq -r '.dev_user // "root"' "$CONFIG_FILE")
 DEV_UID=$(jq -r '.dev_uid // "0"' "$CONFIG_FILE")
 DEV_GID=$(jq -r '.dev_gid // "0"' "$CONFIG_FILE")
 HOME_DIR=$(jq -r '.home_dir // "/home/ossci"' "$CONFIG_FILE")
+LOCAL_SSH_PORT=$(jq -r '.local_ssh_port // "2222"' "$CONFIG_FILE")
+LOCAL_WEB_PORT=$(jq -r '.local_web_port // "8000"' "$CONFIG_FILE")
 
 YAML_TEMPLATE="${SCRIPT_DIR}/vscode-session-${MODE}.yml"
 
@@ -132,10 +143,10 @@ if [[ "$MODE" == "web" ]]; then
     kubectl logs --follow -n "$NAMESPACE" "$POD_NAME" &
 
     echo "VSCode is ready!"
-    echo "Starting port-forward from localhost:$LOCAL_PORT to pod:$REMOTE_PORT..."
-    echo "Access VSCode in your browser at: http://localhost:$LOCAL_PORT"
+    echo "Starting port-forward from localhost:$LOCAL_WEB_PORT to pod:$REMOTE_PORT..."
+    echo "Access VSCode in your browser at: http://localhost:$LOCAL_WEB_PORT"
     echo "Press Ctrl+C to stop and cleanup."
-    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" "$LOCAL_PORT:$REMOTE_PORT"
+    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" "$LOCAL_WEB_PORT:$REMOTE_PORT"
 else
     # Run SSH setup inside the pod via kubectl exec.
     # Pipes setup-ssh.sh into the pod — no ConfigMap needed.
@@ -152,7 +163,7 @@ else
 
     echo ""
     echo "SSH daemon is ready!"
-    echo "Starting port-forward (localhost:2222 -> pod:22)..."
+    echo "Starting port-forward (localhost:$LOCAL_SSH_PORT -> pod:22)..."
     echo "Please make sure your ~/.ssh/config is setup as instructed in README"
     echo "Once active, open VS Code and select:"
     echo "   'Remote-SSH: Connect to Host...'"
@@ -164,5 +175,5 @@ else
     echo "Your SSH public key has already been added to the pod."
     echo "Press Ctrl+C to stop and clean up."
     echo ""
-    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" 2222:22
+    kubectl port-forward -n "$NAMESPACE" "$POD_NAME" "$LOCAL_SSH_PORT:22"
 fi

--- a/example-templates/interactive/vscode/setup-ssh.sh
+++ b/example-templates/interactive/vscode/setup-ssh.sh
@@ -12,8 +12,9 @@ echo "=== SSH Setup ==="
 echo "User: ${DEV_USER} (UID=${DEV_UID}, GID=${DEV_GID}, home=${HOME_DIR})"
 
 # --- Install openssh-server and sudo ---
-apt-get update -y
-apt-get install -y openssh-server sudo
+echo "Installing openssh-server..."
+apt-get update -y > /dev/null 2>&1
+apt-get install -y openssh-server sudo > /dev/null 2>&1
 
 # --- Generate SSH host keys if missing ---
 if [ ! -f /etc/ssh/ssh_host_rsa_key ]; then


### PR DESCRIPTION
## Summary
- Add `--config` flag to specify alternate config files, enabling multiple concurrent sessions with different images/ports
- Add configurable local forwarding ports (`local_ssh_port`, `local_web_port`) in config.json
- Quiet apt-get output during SSH setup

## Test plan
- [x] Run `./run-vscode-interactive.sh ssh` with default config (backward compatible)
- [x] Run `./run-vscode-interactive.sh --config custom.json ssh` with a custom config using a different local port
- [x] Verify two concurrent sessions work with different `local_ssh_port` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)